### PR TITLE
WIP 에디터가 선택할 수 있는 글꼴 가지수를 줄입니다.(#46)

### DIFF
--- a/app/assets/javascripts/summernote-slowalk.js
+++ b/app/assets/javascripts/summernote-slowalk.js
@@ -18,7 +18,7 @@ var initializeSummernote = function() {
       ],
       height: 500,
       lang: 'ko-KR',
-      fontNames: ['Noto Sans Korean', 'Nanum Myeongjo', 'Nanum Gothic', 'Malgun Gothic', 'gulim', 'Batang','Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', ],
+      fontNames: ['Noto Sans Korean'],
       fontSizes: ['8', '9', '10', '11', '12', '14', '16', '18', '20', '24', '36', '48', '64', '82'],
       fontNamesIgnoreCheck: ['Noto Sans Korean', 'Nanum Myeongjo', 'Nanum Gothic', 'Malgun Gothic', 'gulim', 'Batang'],
       insertTableMaxSize: {


### PR DESCRIPTION
써머노트 에디터가 선택할 수 있는 글꼴 선택 드롭다운 메뉴 전체가 보이도록 글꼴 가지수를 줄입니다.
