### PR TITLE
슬라이드 세로 길이를 2가지로 정하고 처음 대기 시간을 줄입니다.

### DIFF
--- a/app/assets/stylesheets/parti.scss
+++ b/app/assets/stylesheets/parti.scss
@@ -396,6 +396,16 @@ footer{
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23f' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e");
 }
 
+.carousel-inner {
+  height: 100%;
+  .carousel-item {
+    .fill {
+      width: 100%;
+      object-fit: fill;
+    }
+  }
+}
+
 @media (min-width: 768px){
   .navbar{
     padding: 1rem 1.5rem;
@@ -415,6 +425,11 @@ footer{
   .btn-outline-parti{
     display: block;
   }
+  .carousel-inner {
+    .fill {
+      height: 700px;
+    }
+  }
 }
 
 @media (max-width: 768px){
@@ -426,17 +441,10 @@ footer{
     width: 100%;
     max-width: 344px;
   }
-
-  .carousel-inner{
-    width: 100%;
-    height: 520px;
-    .carousel-item{
-      width: 100%;
-      height: 520px;
-      img{
-        height: 100%;
-        object-fit: fill;
-      }
+  .carousel-inner {
+    height: 460px;
+    .fill {
+      height: 460px;
     }
   }
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -7,19 +7,19 @@
     .carousel-inner
       .carousel-item.active
         = link_to post_path(12) do
-          = image_tag Post.find(12).cover, class: "d-block w-100", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\'', loading: 'lazy'
+          = image_tag Post.find(12).cover, class: "fill", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\''
         .carousel-caption.d-none.d-block
           %h2.badge-primary
             = Post.find(12).title
       .carousel-item
         = link_to post_path(35) do
-          = image_tag Post.find(35).cover, class: "d-block w-100", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\'', loading: 'lazy'
+          = image_tag Post.find(35).cover, class: "fill", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\''
         .carousel-caption.d-none.d-block
           %h2.badge-primary
             = Post.find(35).title
       .carousel-item
         = link_to post_path(2) do
-          = image_tag Post.find(2).cover, class: "d-block w-100", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\'', loading: 'lazy'
+          = image_tag Post.find(2).cover, class: "fill", onerror: 'this.onerror=null;this.src=\'' + asset_path('logo.png') +'\''
         .carousel-caption.d-none.d-block
           %h2.badge-primary
             = Post.find(2).title


### PR DESCRIPTION
이슈 #45
* 슬라이드 커버 이미지 세로 길이를 고정합니다. 
* 슬라이드 전환시간을 줄입니다.