### PR TITLE
Update index.html.haml 

### DIFF
--- a/app/views/archives/index.html.haml
+++ b/app/views/archives/index.html.haml
@@ -12,5 +12,5 @@
         - @archives.each do |archive|
           .col-md-4.col-sm-6.mb-4
             = render archive
-
+<!-- 아카이브 생성시 작성한 링크와 메인페이지에 반영되는 링크가 일치하지 않는 오류 -->
     = paginate @archives

--- a/app/views/archives/show.html.haml
+++ b/app/views/archives/show.html.haml
@@ -1,3 +1,5 @@
+<!-- 새로 가입한 사용자가 업로드한 아카이브 소식이 화면에 노출되지 않는 오류 --> 
+
 - set_tags(og_title: "#{@archive.title} 아카이브 - 빠띠 데이터퍼블릭", og_url: archive_link(@archive), og_image: rails_blob_url(@archive.cover))
 = render "cover", archive: @archive
 


### PR DESCRIPTION
아카이브 생성시 작성한 링크와 메인페이지에 반영되는 링크가 일치하지 않는 오류 @wagurano 
(아카이브 생성시 작성한 링크와 자동으로 주어지는 링크 두개가 태그로 동시에 메인페이지 노출)
새로 가입한 사용자가 업로드한 아카이브 소식이 화면에 노출되지 않는 오류
